### PR TITLE
fix: pass model selection and file attachments to backend

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -4,18 +4,25 @@ const SERVER_URL = 'http://localhost:3001';
 
 // Expose safe API to renderer process via contextBridge
 contextBridge.exposeInMainWorld('electronAPI', {
-  // Send a chat message to the backend with chat ID for session management
-  sendMessage: async (message, chatId) => {
+  // Send a chat message to the backend with chat ID, model selection, and file attachments
+  sendMessage: async (message, chatId, options = {}) => {
     return new Promise((resolve, reject) => {
       console.log('[PRELOAD] Sending message to backend:', message);
       console.log('[PRELOAD] Chat ID:', chatId);
+      console.log('[PRELOAD] Model:', options.model);
+      console.log('[PRELOAD] Files:', options.files?.length || 0);
 
       fetch(`${SERVER_URL}/api/chat`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ message, chatId })
+        body: JSON.stringify({
+          message,
+          chatId,
+          model: options.model,
+          files: options.files
+        })
       })
         .then(response => {
           if (!response.ok) {

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -466,8 +466,16 @@ async function handleSendMessage(e) {
   const contentDiv = assistantMessage.querySelector('.message-content');
 
   try {
-    // Pass chatId for session management
-    const response = await window.electronAPI.sendMessage(message, currentChatId);
+    // Pass chatId, model, and files for full functionality
+    const response = await window.electronAPI.sendMessage(message, currentChatId, {
+      model: selectedModel,
+      files: attachedFiles.length > 0 ? attachedFiles : undefined
+    });
+
+    // Clear attached files after sending
+    attachedFiles = [];
+    renderAttachedFiles(isFirstMessage ? 'home' : 'chat');
+
     const reader = await response.getReader();
     let buffer = '';
     let hasContent = false;


### PR DESCRIPTION
Previously, model selector and file attachments in the UI were non-functional - selections were not sent to the backend.

- preload.js: Accept options object with model and files
- renderer.js: Pass selectedModel and attachedFiles to sendMessage
- server.js: Use model in query options, prepend files to prompt

