### PR TITLE
feat: Add BROWSER_PATH configuration for custom browser support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,12 @@ ANTHROPIC_API_KEY=your-api-key-here
 
 # Composio API key for Tool Router
 COMPOSIO_API_KEY=your-composio-api-key-here
+
+# Opencode SDK browser configuration
+# Optional: Path to browser executable (e.g., Chromium, Firefox)
+# Leave empty to use system default browser
+# Examples:
+# BROWSER_PATH=/Applications/Chromium.app/Contents/MacOS/Chromium
+# BROWSER_PATH=/usr/bin/chromium-browser
+# BROWSER_PATH=C:\Program Files\Chromium\Application\chrome.exe
+BROWSER_PATH=

--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ OPENCODE_PORT=4096
 
 # Composio Integration
 COMPOSIO_API_KEY=your-composio-api-key
+
+# Browser Configuration (optional)
+# Specify a custom browser executable path for Opencode's browser automation
+# Useful if your default browser is not supported (e.g., Brave)
+# Leave empty to use system default browser
+# Examples:
+# macOS: BROWSER_PATH=/Applications/Chromium.app/Contents/MacOS/Chromium
+# Linux: BROWSER_PATH=/usr/bin/chromium-browser
+# Windows: BROWSER_PATH=C:\Program Files\Chromium\Application\chrome.exe
+BROWSER_PATH=
 ```
 
 **Provider Selection:**
@@ -338,6 +348,18 @@ open-claude-cowork/
 - Check that model identifiers match Opencode format (e.g., `opencode/big-pickle`)
 - Review Opencode API documentation for available models
 - Check server logs for Opencode SDK initialization errors
+
+**"Browser not supported as default browser"**
+- Opencode's browser automation may not support all browsers (e.g., Brave)
+- Set `BROWSER_PATH` in `.env` to specify a supported browser (Chromium, Firefox, or WebKit)
+- Common browser paths:
+  - **macOS Chromium**: `/Applications/Chromium.app/Contents/MacOS/Chromium`
+  - **macOS Firefox**: `/Applications/Firefox.app/Contents/MacOS/firefox`
+  - **Linux Chromium**: `/usr/bin/chromium-browser`
+  - **Linux Firefox**: `/usr/bin/firefox`
+  - **Windows Chromium**: `C:\Program Files\Chromium\Application\chrome.exe`
+- Restart the backend server after changing `.env`
+- Leave `BROWSER_PATH` empty to use the system default browser
 
 ---
 

--- a/server/providers/index.js
+++ b/server/providers/index.js
@@ -71,8 +71,11 @@ export async function clearProviderCache() {
 export async function initializeProviders() {
   console.log('[Providers] Initializing providers...');
   try {
-    // Get and initialize opencode provider
-    const opencodeProvider = getProvider('opencode');
+    // Get and initialize opencode provider with browser configuration
+    const opencodeConfig = {
+      browserPath: process.env.BROWSER_PATH
+    };
+    const opencodeProvider = getProvider('opencode', opencodeConfig);
     await opencodeProvider.initialize();
     console.log('[Providers] Opencode provider initialized');
   } catch (error) {

--- a/server/providers/opencode-provider.js
+++ b/server/providers/opencode-provider.js
@@ -15,6 +15,7 @@ export class OpencodeProvider extends BaseProvider {
     this.port = config.port || 4096;
     this.useExistingServer = config.useExistingServer || false;
     this.existingServerUrl = config.existingServerUrl || null;
+    this.browserPath = config.browserPath || process.env.BROWSER_PATH || null;
   }
 
   get name() {
@@ -37,10 +38,20 @@ export class OpencodeProvider extends BaseProvider {
       } else {
         // Create new Opencode server and client
         console.log('[Opencode] Creating new server on', this.hostname, ':', this.port);
-        const { client, server } = await createOpencode({
+        const createOptions = {
           hostname: this.hostname,
           port: this.port
-        });
+        };
+        
+        // Add browser path if configured
+        if (this.browserPath) {
+          console.log('[Opencode] Using custom browser:', this.browserPath);
+          createOptions.browser = {
+            executablePath: this.browserPath
+          };
+        }
+        
+        const { client, server } = await createOpencode(createOptions);
         this.client = client;
         this.serverInstance = server;
       }


### PR DESCRIPTION
## Summary
This PR adds support for configuring a custom browser executable path for Opencode's browser automation features. This resolves issue #4 where users with unsupported default browsers (like Brave) could not use the application.

## Changes
- Added `BROWSER_PATH` environment variable to `.env.example` with examples for macOS, Linux, and Windows
- Updated `OpencodeProvider` to accept `browserPath` configuration parameter
- Modified provider initialization to pass browser path to `createOpencode` function when configured
- Added comprehensive documentation in README with:
  - Environment variable setup instructions
  - Common browser paths for different platforms
  - Troubleshooting section for browser configuration issues

## Testing
- Tested configuration passing through provider initialization
- Verified environment variable is correctly read from process.env
- Checked that browser option is only added when BROWSER_PATH is set

## Impact
- Allows users to specify a supported browser (Chromium, Firefox, WebKit) instead of relying on system default
- Fixes compatibility issues for users with Brave or other unsupported browsers as default
- Backwards compatible - empty BROWSER_PATH uses system default behavior

Fixes #4