### PR TITLE
feat: add Claude via Vertex AI as a provider option

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -91,7 +91,13 @@
                           <polyline points="20 6 9 17 4 12"></polyline>
                         </svg>
                       </div>
-                      <span class="item-desc">Claude Agent SDK</span>
+                      <span class="item-desc">Claude API</span>
+                    </div>
+                    <div class="dropdown-item" data-value="claude-vertex">
+                      <div class="item-row">
+                        <span class="item-label">Claude (Vertex AI)</span>
+                      </div>
+                      <span class="item-desc">Google Cloud Vertex AI</span>
                     </div>
                     <div class="dropdown-item" data-value="opencode">
                       <div class="item-row">
@@ -215,7 +221,13 @@
                               <polyline points="20 6 9 17 4 12"></polyline>
                             </svg>
                           </div>
-                          <span class="item-desc">Claude Agent SDK</span>
+                          <span class="item-desc">Claude API</span>
+                        </div>
+                        <div class="dropdown-item" data-value="claude-vertex">
+                          <div class="item-row">
+                            <span class="item-label">Claude (Vertex AI)</span>
+                          </div>
+                          <span class="item-desc">Google Cloud Vertex AI</span>
                         </div>
                         <div class="dropdown-item" data-value="opencode">
                           <div class="item-row">

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -54,6 +54,11 @@ const providerModels = {
     { value: 'claude-sonnet-4-5-20250514', label: 'Sonnet 4.5', desc: 'Best for everyday tasks', default: true },
     { value: 'claude-haiku-4-5-20250514', label: 'Haiku 4.5', desc: 'Fastest for quick answers' }
   ],
+  'claude-vertex': [
+    { value: 'claude-opus-4-5-20250514', label: 'Opus 4.5', desc: 'Most capable for complex work' },
+    { value: 'claude-sonnet-4-5-20250514', label: 'Sonnet 4.5', desc: 'Best for everyday tasks', default: true },
+    { value: 'claude-haiku-4-5-20250514', label: 'Haiku 4.5', desc: 'Fastest for quick answers' }
+  ],
   opencode: [
     // Opencode Zen (Free)
     { value: 'opencode/big-pickle', label: 'Big Pickle', desc: 'Reasoning model', default: true },
@@ -173,7 +178,12 @@ function loadAllChats() {
 
 // Update provider UI across all dropdowns
 function updateProviderUI(provider) {
-  const providerLabel = provider === 'claude' ? 'Claude' : 'Opencode';
+  const providerLabels = {
+    'claude': 'Claude',
+    'claude-vertex': 'Claude (Vertex AI)',
+    'opencode': 'Opencode'
+  };
+  const providerLabel = providerLabels[provider] || provider;
   document.querySelectorAll('.provider-selector .provider-label').forEach(l => {
     l.textContent = providerLabel;
   });

--- a/server/providers/claude-vertex-provider.js
+++ b/server/providers/claude-vertex-provider.js
@@ -1,0 +1,87 @@
+import { ClaudeProvider } from './claude-provider.js';
+
+/**
+ * Claude via Vertex AI provider implementation.
+ * Extends ClaudeProvider to route requests through Google Cloud Vertex AI
+ * instead of the direct Anthropic API.
+ *
+ * Requires:
+ *   - ANTHROPIC_VERTEX_PROJECT_ID (GCP project ID)
+ *   - CLOUD_ML_REGION (GCP region, e.g. us-east5)
+ *   - Google Cloud credentials (gcloud auth application-default login)
+ */
+export class ClaudeVertexProvider extends ClaudeProvider {
+  constructor(config = {}) {
+    super(config);
+
+    this.vertexProjectId = process.env.ANTHROPIC_VERTEX_PROJECT_ID || config.vertexProjectId;
+    this.vertexRegion = process.env.CLOUD_ML_REGION || config.vertexRegion || 'us-east5';
+  }
+
+  get name() {
+    return 'claude-vertex';
+  }
+
+  async initialize() {
+    if (!this.vertexProjectId) {
+      console.warn('[Claude-Vertex] ANTHROPIC_VERTEX_PROJECT_ID not set. Vertex AI provider will fail at query time.');
+    } else {
+      console.log(`[Claude-Vertex] Configured for project: ${this.vertexProjectId}, region: ${this.vertexRegion}`);
+    }
+  }
+
+  /**
+   * Override query to inject Vertex AI environment variables.
+   * The Claude Agent SDK reads these env vars to route through Vertex AI.
+   */
+  async *query(params) {
+    if (!this.vertexProjectId) {
+      yield {
+        type: 'error',
+        message: 'Vertex AI not configured. Set ANTHROPIC_VERTEX_PROJECT_ID and CLOUD_ML_REGION in your .env file.',
+        provider: this.name
+      };
+      return;
+    }
+
+    // Store original env values
+    const origUseVertex = process.env.CLAUDE_CODE_USE_VERTEX;
+    const origProjectId = process.env.ANTHROPIC_VERTEX_PROJECT_ID;
+    const origRegion = process.env.CLOUD_ML_REGION;
+
+    try {
+      // Set Vertex AI env vars for the Claude Agent SDK process
+      process.env.CLAUDE_CODE_USE_VERTEX = '1';
+      process.env.ANTHROPIC_VERTEX_PROJECT_ID = this.vertexProjectId;
+      process.env.CLOUD_ML_REGION = this.vertexRegion;
+
+      console.log(`[Claude-Vertex] Routing through Vertex AI (project: ${this.vertexProjectId}, region: ${this.vertexRegion})`);
+
+      // Delegate to parent ClaudeProvider's query
+      for await (const chunk of super.query(params)) {
+        // Re-tag chunks with this provider's name
+        if (chunk.provider) {
+          chunk.provider = this.name;
+        }
+        yield chunk;
+      }
+    } finally {
+      // Restore original env values
+      if (origUseVertex === undefined) {
+        delete process.env.CLAUDE_CODE_USE_VERTEX;
+      } else {
+        process.env.CLAUDE_CODE_USE_VERTEX = origUseVertex;
+      }
+      if (origProjectId === undefined) {
+        delete process.env.ANTHROPIC_VERTEX_PROJECT_ID;
+      } else {
+        process.env.ANTHROPIC_VERTEX_PROJECT_ID = origProjectId;
+      }
+      if (origRegion === undefined) {
+        delete process.env.CLOUD_ML_REGION;
+      } else {
+        process.env.CLOUD_ML_REGION = origRegion;
+      }
+    }
+  }
+}

--- a/server/providers/index.js
+++ b/server/providers/index.js
@@ -1,9 +1,11 @@
 import { ClaudeProvider } from './claude-provider.js';
+import { ClaudeVertexProvider } from './claude-vertex-provider.js';
 import { OpencodeProvider } from './opencode-provider.js';
 
 // Provider registry
 const providers = {
   claude: ClaudeProvider,
+  'claude-vertex': ClaudeVertexProvider,
   opencode: OpencodeProvider
 };
 
@@ -78,9 +80,18 @@ export async function initializeProviders() {
   } catch (error) {
     console.error('[Providers] Error initializing providers:', error.message);
   }
+  try {
+    // Get and initialize claude-vertex provider
+    const vertexProvider = getProvider('claude-vertex');
+    await vertexProvider.initialize();
+    console.log('[Providers] Claude Vertex provider initialized');
+  } catch (error) {
+    console.error('[Providers] Error initializing Claude Vertex provider:', error.message);
+  }
 }
 
 // Export classes for direct use
 export { ClaudeProvider } from './claude-provider.js';
+export { ClaudeVertexProvider } from './claude-vertex-provider.js';
 export { OpencodeProvider } from './opencode-provider.js';
 export { BaseProvider } from './base-provider.js';


### PR DESCRIPTION
Adds support for accessing Claude through Google Cloud Vertex AI as an alternative to the direct Anthropic API key.

- New claude-vertex provider extending ClaudeProvider
- Provider dropdown option in both home and chat views
- Configured via ANTHROPIC_VERTEX_PROJECT_ID and CLOUD_ML_REGION env vars
- Auth via gcloud application-default credentials