### PR TITLE
feat: add AWS Bedrock support as alternative to Anthropic API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,28 @@
-# Anthropic API key for Claude Agent SDK
-ANTHROPIC_API_KEY=your-api-key-here
-
 # Composio API key for Tool Router
 COMPOSIO_API_KEY=your-composio-api-key-here
+
+# ===========================================
+# Claude API Configuration
+# Choose ONE of the two options below:
+# ===========================================
+
+# --- Option 1: Anthropic API (Direct) ---
+# Get your key at: https://console.anthropic.com
+ANTHROPIC_API_KEY=your-api-key-here
+
+# --- Option 2: AWS Bedrock ---
+# Use Claude through your AWS account instead of a direct Anthropic API key.
+# Uncomment and fill in the lines below, and leave ANTHROPIC_API_KEY empty.
+#
+# CLAUDE_CODE_USE_BEDROCK=1
+# AWS_REGION=us-east-1
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+#
+# Or use an AWS profile instead of access keys:
+# AWS_PROFILE=your-profile-name
+#
+# Optional: pin specific model versions for Bedrock
+# ANTHROPIC_DEFAULT_OPUS_MODEL=us.anthropic.claude-opus-4-6-v1
+# ANTHROPIC_DEFAULT_SONNET_MODEL=us.anthropic.claude-sonnet-4-6
+# ANTHROPIC_DEFAULT_HAIKU_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0

--- a/README.md
+++ b/README.md
@@ -130,13 +130,44 @@ See [Secure Clawdbot Documentation](./clawd/README.md) for full setup.
 ### API Keys
 
 You need:
-- **Anthropic API key** from [console.anthropic.com](https://console.anthropic.com)
 - **Composio API key** from [app.composio.dev](https://app.composio.dev)
+- **One** of the following for Claude:
+  1. **Anthropic API key** from [console.anthropic.com](https://console.anthropic.com),
+  2. **AWS Bedrock** credentials (use Claude through your own AWS account)
 - **Opencode API key** (optional) from [opencode.dev](https://opencode.dev)
 
 ```bash
 cp .env.example .env
 # Edit .env with your keys
+```
+
+### Using AWS Bedrock (instead of Anthropic API key)
+
+If you prefer to use Claude through **AWS Bedrock** instead of a direct Anthropic API key, set these environment variables in your `.env`:
+
+```bash
+CLAUDE_CODE_USE_BEDROCK=1
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret-key
+```
+
+Or use an **AWS profile** instead of access keys:
+
+```bash
+CLAUDE_CODE_USE_BEDROCK=1
+AWS_REGION=us-east-1
+AWS_PROFILE=your-profile-name
+```
+
+> **Note:** Make sure Claude models are [enabled in your AWS Bedrock console](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) for your region before using this option.
+
+Optionally, pin specific model versions:
+
+```bash
+ANTHROPIC_DEFAULT_OPUS_MODEL=us.anthropic.claude-opus-4-6-v1
+ANTHROPIC_DEFAULT_SONNET_MODEL=us.anthropic.claude-sonnet-4-6
+ANTHROPIC_DEFAULT_HAIKU_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0
 ```
 
 ### Skills
@@ -180,7 +211,9 @@ open-claude-cowork/
 | Issue | Solution |
 |-------|----------|
 | Can't connect to backend | Ensure server is running on port 3001 |
-| API key error | Check `.env` - Anthropic keys start with `sk-ant-` |
+| Anthropic API key error | Check `.env` - Anthropic keys start with `sk-ant-` |
+| Bedrock auth error | Verify `CLAUDE_CODE_USE_BEDROCK=1` is set, AWS credentials are valid, and Claude models are enabled in your Bedrock console |
+| Bedrock region error | Ensure `AWS_REGION` is set to a region where Claude is available (e.g. `us-east-1`, `us-west-2`, `eu-west-1`) |
 | Session not persisting | Check server logs for session ID |
 | Streaming slow | Check firewall/network for SSE connections |
 

--- a/setup.sh
+++ b/setup.sh
@@ -54,24 +54,72 @@ else
     echo ""
 fi
 
-# Prompt for Anthropic API key
-echo "API Key Configuration"
+# Prompt for Claude API configuration
+echo "Claude API Configuration"
 echo "------------------------"
 echo ""
-echo "You'll need an Anthropic API key from: https://console.anthropic.com"
+echo "Choose how to connect to Claude:"
+echo "  1) Anthropic API key (direct) - from https://console.anthropic.com"
+echo "  2) AWS Bedrock - use Claude through your AWS account"
 echo ""
-read -p "Enter your Anthropic API key (or press Enter to skip): " anthropic_key
+read -p "Enter your choice (1 or 2, or press Enter to skip): " claude_choice
 
-if [ ! -z "$anthropic_key" ]; then
-    # Update .env file with Anthropic key
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "s/ANTHROPIC_API_KEY=.*/ANTHROPIC_API_KEY=$anthropic_key/" .env
-    else
-        sed -i "s/ANTHROPIC_API_KEY=.*/ANTHROPIC_API_KEY=$anthropic_key/" .env
+if [ "$claude_choice" = "1" ]; then
+    read -p "Enter your Anthropic API key: " anthropic_key
+    if [ ! -z "$anthropic_key" ]; then
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s/ANTHROPIC_API_KEY=.*/ANTHROPIC_API_KEY=$anthropic_key/" .env
+        else
+            sed -i "s/ANTHROPIC_API_KEY=.*/ANTHROPIC_API_KEY=$anthropic_key/" .env
+        fi
+        echo "Anthropic API key saved to .env"
     fi
-    echo "Anthropic API key saved to .env"
+elif [ "$claude_choice" = "2" ]; then
+    echo ""
+    echo "AWS Bedrock Configuration"
+    echo "Make sure Claude models are enabled in your AWS Bedrock console."
+    echo ""
+    read -p "Enter your AWS region (default: us-east-1): " aws_region
+    aws_region=${aws_region:-us-east-1}
+
+    echo ""
+    echo "Authentication method:"
+    echo "  1) AWS access keys (ACCESS_KEY_ID + SECRET_ACCESS_KEY)"
+    echo "  2) AWS profile name"
+    echo ""
+    read -p "Enter your choice (1 or 2): " auth_choice
+
+    # Enable Bedrock in .env
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s/# CLAUDE_CODE_USE_BEDROCK=1/CLAUDE_CODE_USE_BEDROCK=1/" .env
+        sed -i '' "s/# AWS_REGION=.*/AWS_REGION=$aws_region/" .env
+    else
+        sed -i "s/# CLAUDE_CODE_USE_BEDROCK=1/CLAUDE_CODE_USE_BEDROCK=1/" .env
+        sed -i "s/# AWS_REGION=.*/AWS_REGION=$aws_region/" .env
+    fi
+
+    if [ "$auth_choice" = "1" ]; then
+        read -p "Enter your AWS Access Key ID: " aws_key
+        read -p "Enter your AWS Secret Access Key: " aws_secret
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s/# AWS_ACCESS_KEY_ID=.*/AWS_ACCESS_KEY_ID=$aws_key/" .env
+            sed -i '' "s/# AWS_SECRET_ACCESS_KEY=.*/AWS_SECRET_ACCESS_KEY=$aws_secret/" .env
+        else
+            sed -i "s/# AWS_ACCESS_KEY_ID=.*/AWS_ACCESS_KEY_ID=$aws_key/" .env
+            sed -i "s/# AWS_SECRET_ACCESS_KEY=.*/AWS_SECRET_ACCESS_KEY=$aws_secret/" .env
+        fi
+        echo "AWS Bedrock credentials saved to .env"
+    elif [ "$auth_choice" = "2" ]; then
+        read -p "Enter your AWS profile name: " aws_profile
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s/# AWS_PROFILE=.*/AWS_PROFILE=$aws_profile/" .env
+        else
+            sed -i "s/# AWS_PROFILE=.*/AWS_PROFILE=$aws_profile/" .env
+        fi
+        echo "AWS Bedrock profile saved to .env"
+    fi
 else
-    echo "Skipped Anthropic API key. Please add it to .env manually."
+    echo "Skipped Claude API configuration. Please edit .env manually."
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

- Adds **AWS Bedrock** as an alternative to using a direct Anthropic API key
- Users can set `CLAUDE_CODE_USE_BEDROCK=1` + AWS credentials in `.env` — **no code changes required**, the Claude Agent SDK routes through Bedrock automatically
- Updates `.env.example` with documented Bedrock configuration options
- Updates `setup.sh` with an interactive Bedrock setup flow (region, access keys vs AWS profile)
- Adds Bedrock-specific troubleshooting entries to README

## Motivation

Several users want to use Claude through their existing AWS accounts rather than a separate Anthropic API key. Related to the pattern of issues requesting alternative cloud providers (#10, #11 for Vertex AI).

## Changes

| File | What changed |
|------|-------------|
| `.env.example` | Expanded with Bedrock env vars, model pinning options, and clearer structure |
| `README.md` | New "Using AWS Bedrock" section under Configuration + Bedrock troubleshooting rows |
| `setup.sh` | Interactive menu: Anthropic API key or AWS Bedrock, with sub-options for access keys vs AWS profile |
